### PR TITLE
feat: add dynamic sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://mysecurepassword.fr/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import { MetadataRoute } from "next";
+import { env } from "@/config/env";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = env.APP_URL.replace(/\/$/, "");
+  const routes = ["", "/legal", "/privacy"];
+
+  return routes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+  }));
+}


### PR DESCRIPTION
## Summary
- create dynamic sitemap using Next.js metadata route
- include root and legal/privacy pages based on environment URL

## Testing
- `npm run lint`
- `npm run test:run` *(fails: Favicon Integration Tests fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_68a4f3a7d508833194d3e439921379f9